### PR TITLE
Fix wrong information in about ps30 and linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Here are some examples of some cool shaders:\
 **GMod Volumetric Clouds (Evgeny Akabenko):**\
 ![Untitled](https://github.com/user-attachments/assets/0aae45f1-9d7d-49b3-acc3-df3ae7ed8fcd)\
 **Half Life: Alyx liquid shader (Valve):**\
-![ebd09ce02b4b9b7c3d59eb442ee6afe22f20d291](https://github.com/user-attachments/assets/0339658e-a9ae-4b0a-8aff-c0f55a11ae46)\
+![ebd09ce02b4b9b7c3d59eb442ee6afe22f20d291](https://github.com/user-attachments/assets/0339658e-a9ae-4b0a-8aff-c0f55a11ae46)
 
 # The Shader Pipeline
 All graphics APIs, have something called a [Graphics Pipeline](https://en.wikipedia.org/wiki/Graphics_pipeline). This is a generalized, fixed set of stages which function to transform a 3 dimensional scene, into something the screen can display.
@@ -100,10 +100,6 @@ Now, for reference, the name of a shader is very important, so lets split it int
 
 You must ENSURE that the name stays exactly in this format, or the tools provided won't work.
 
-If you choose the `30` shader version notice that texture sampling on vertex shaders does not work on Linux.
-There could be other problems with 3.0 Shaders on Linux, as everything has not been tested yet.
-If you notice any other issues with your shaders on Linux, please open a pull request or submit an issue.
-
 Now, we're going to overwrite an existing shader with a new one.\
 Drag `example1_ps2x.hlsl` on top of `build_single_shader.bat` and it should compile and automatically put the shader into `fxc`, which is where GMod shaders are loaded from.\
 Compiled shaders are `.vcs` files, which stands for `Valve Compiled Shader`.
@@ -118,6 +114,10 @@ If the square is red, we haven't overwritten anything and you've probably missed
 
 > [!TIP]
 > When you eventually start developing your own shaders, make sure to give them a distinct name, or you might get conflictions
+
+> [!NOTE]
+> Shader model `30` is untested on Linux systems and (supposedly,) certain features may not work as intended.\
+> If you notice any problems with Linux shaders, please open a pull request or submit an issue for documentation purposes.
 
 ![image](https://github.com/user-attachments/assets/f009c4a2-4e2b-4b65-a297-7f8fa9434880)
 
@@ -209,7 +209,9 @@ If none of that made sense, all you really need to know is that you should avoid
 
 ### Loops
 
-In this guide, We are using shader model 20b. Model 20b is interesting because (as far as I'm aware) all loops need to be [unrolled](https://en.wikipedia.org/wiki/Loop_unrolling), and cannot be dynamic (Shader model 30 does however support dynamic loops).
+In this guide, We are using shader model 20b. Model 20b is interesting because (as far as I'm aware) all loops need to be [unrolled](https://en.wikipedia.org/wiki/Loop_unrolling), and cannot be dynamic.
+
+Shader model 30 does support dynamic loops, but for now I would suggest avoiding them, as infinite loops on the GPU will lock up your computer and usually require a full system restart.
 
 To continue, navigate to `gmod_shader_guide/shaders` and take a look at `example4_ps2x.hlsl`
 

--- a/README.md
+++ b/README.md
@@ -95,10 +95,14 @@ Now, for reference, the name of a shader is very important, so lets split it int
 1. `example1` - The name of the shader, this can be anything you want.
 2. `_` - Required underscore to separate the name and the rest of the data.
 3. `ps` - Stands for Pixel Shader, can also be `vs` (Can you guess what it stands for?)
-4. `2x` - The shader version. I will be using `2x`, as it is the most supported. `30` is also valid and has less restrictions, but does not work on native Linux
+4. `2x` - The shader version. I will be using `2x`, as it is the most supported. `30` is also valid and has less restrictions.
 5. `.hlsl` - The file extension, all source shaders use hlsl
 
 You must ENSURE that the name stays exactly in this format, or the tools provided won't work.
+
+If you choose the `30` shader version notice that texture sampling on vertex shaders does not work on Linux.
+There could be other problems with 3.0 Shaders on Linux, as everything has not been tested yet.
+If you notice any other issues with your shaders on Linux, please open a pull request or submit an issue.
 
 Now, we're going to overwrite an existing shader with a new one.\
 Drag `example1_ps2x.hlsl` on top of `build_single_shader.bat` and it should compile and automatically put the shader into `fxc`, which is where GMod shaders are loaded from.\
@@ -205,9 +209,7 @@ If none of that made sense, all you really need to know is that you should avoid
 
 ### Loops
 
-In this guide, We are using shader model 20b. Model 20b is interesting because (as far as I'm aware) all loops need to be [unrolled](https://en.wikipedia.org/wiki/Loop_unrolling), and cannot be dynamic.
-
-Shader model 30 does however support dynamic loops, but is not supported on Linux systems.
+In this guide, We are using shader model 20b. Model 20b is interesting because (as far as I'm aware) all loops need to be [unrolled](https://en.wikipedia.org/wiki/Loop_unrolling), and cannot be dynamic (Shader model 30 does however support dynamic loops).
 
 To continue, navigate to `gmod_shader_guide/shaders` and take a look at `example4_ps2x.hlsl`
 


### PR DESCRIPTION
ps30 shaders can work on linux, here an exemple with the https://github.com/Srlion/RNDX library

![image](https://github.com/user-attachments/assets/04b483a1-bc56-4981-a616-dcfeca79f886)


thanks to srlion and papasoco for the correction and the screen