### PR TITLE
make build_single_shader.bat exit immediately if compilation is successful

### DIFF
--- a/shaders/build_single_shader.bat
+++ b/shaders/build_single_shader.bat
@@ -18,7 +18,16 @@ if "%char7%" == "3" (
 	ShaderCompile.exe /O 3 -ver 20b -shaderpath "%cd%" ./%1
 )
 
+REM Check error level (exit code)
+
+REM this actually means "if %ERRORLEVEL% >= 1", but windows being windows thinks the former is invalid syntax
+if ERRORLEVEL 1 (
+    rmdir /s /q "./shaders"
+    echo Error while compiling: examine output above
+    pause
+    exit 1
+)
+
 xcopy /e /y /q "./shaders/fxc" "./fxc"
 rmdir /s /q "./shaders"
-
-pause
+exit 0


### PR DESCRIPTION
yeah

doesn't exit if compilation failed, so you can still examine errors